### PR TITLE
feat: added listeningTcp event so callers can detect listen success/fail

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,12 +78,12 @@ module.exports = {
 
 };
 
-/* Export all the record types at the top-level */
-var subdir = path.join(__dirname, 'records');
-fs.readdirSync(subdir).forEach(function (f) {
-        var name = path.basename(f);
-        if (/\w+\.js/.test(name)) {
-                var k = name.split('.').shift().toUpperCase() + 'Record';
-                module.exports[k] = require(path.join(subdir, f));
-        }
-});
+module.exports.ARecord = require('./records/a.js');
+module.exports.AAAARecord = require('./records/aaaa.js');
+module.exports.CNAMERecord = require('./records/cname.js');
+module.exports.MXRecord = require('./records/mx.js');
+module.exports.NSRecord = require('./records/ns.js');
+module.exports.PTRRecord = require('./records/ptr.js');
+module.exports.SOARecord = require('./records/soa.js');
+module.exports.SRVRecord = require('./records/srv.js');
+module.exports.TXTRecord = require('./records/txt.js');

--- a/lib/server.js
+++ b/lib/server.js
@@ -205,6 +205,10 @@ Server.prototype.listenTcp = function listenTcp(opts, callback) {
                 self.emit('error', err);
         });
 
+        this._server.on('listening', function () {
+                self.emit('listeningTcp');
+        });
+
         this._server.listen(opts.port, opts.address, callback);
 };
 


### PR DESCRIPTION
I have code that uses mname, and listens on both TCP and UDP.

Since my code is async, I usually do this sort of thing when setting up a server:

```
new Promise((resolve, reject) => {
  server = mname.createServer();

  server.once('listening', resolve);
  server.once('error', reject);

  server.listen(...);
})
```

This works for `listenUdp()`, however no similar event is emitted for `listenTcp()`, and there's no way I can get around this as the TCP socket is created inside `listen()`, so I cannot register a listener for the socket's `listening` event before mname calls `socket.listen()`.

This PR causes mname to emit a `listeningTcp` event when `listenTcp()` is called and the socket suceeds. This allows callers to detect when the server is ready, and also allows callers to distinguish between UDP and TCP servers being ready when using both.